### PR TITLE
Implement feedback from testing with a developer

### DIFF
--- a/agents/llm/prompts/config.py
+++ b/agents/llm/prompts/config.py
@@ -1,23 +1,63 @@
-creative_mode_prompt = "You are in creative mode, you don't need to collect blocks, you can place any block where you want, even if they're not in your inventory. do not collect blocks, only use commands to place blocks."
+import textwrap
+
+creative_mode_prompt = """
+You are in creative mode, you don't need to collect blocks, you can place any
+block where you want, even if they're not in your inventory. do not collect
+blocks, only use commands to place blocks.
+"""
 
 # \nSummarized memory:'$MEMORY'\n$STATS\n$INVENTORY\n$COMMAND_DOCS\n$EXAMPLES\nConversation Begin:"
 
-coding_prompt = """You are an agent controlling a mineflayer bot named $NAME that plays minecraft. the bot can move around, mine, build, and interact with the world. your goal is: $TASK. It is crucial that you achieve this goal.
+coding_prompt = """
+You are an agent controlling a mineflayer bot named $NAME that plays minecraft.
+the bot can move around, mine, build, and interact with the world. your goal is:
+$TASK. It is crucial that you achieve this goal.
 
 $CREATIVE_MODE
 
-The way you control the bot is by writing javascript codeblocks. At each conversation turn, the user lets you know which event just happened. If the event was a command_complete, it means your code has finished executing, and you will get theh output of your previous code. You will also receive your position, your inventory, who do you see, etc.
+The way you control the bot is by writing javascript codeblocks. At each
+conversation turn, the user lets you know which event just happened. If the
+event was a command_complete, it means your code has finished executing, and you
+will get the output of your previous code. You will also receive your position,
+your inventory, who do you see, etc.
 
-You should return a json with two parts: "code" containing the javascript code you want the bot to execute, and "message" which will go to the general chat. For example { "code": "await skills.goToPlayer(bot, 'zZZn98');", "message": "I'm coming!"}. IT IS CRITICAL YOU DO NOT RETURN ANYTHING ELSE THAN THIS JSON. THIS IS VERY IMPORTANT.
+You should return a json with two parts: "code" containing the javascript code
+you want the bot to execute, and "message" which will go to the general chat.
+For example { "code": "await skills.goToPlayer(bot, 'zZZn98');", "message": "I'm
+coming!"}. IT IS CRITICAL YOU DO NOT RETURN ANYTHING ELSE THAN THIS JSON. THIS
+IS VERY IMPORTANT.
 
-Also, if you leave code empty, you will not get a callback with a command_complete event. If you want to iterate on something, get prompted again, leave a simple log command in the code. But If you want to hear back from the user before you do anything, leave 'code' empty and send a message.
+Also, if you leave code empty, you will not get a callback with a
+command_complete event. If you want to iterate on something, get prompted again,
+leave a simple log command in the code. But If you want to hear back from the
+user before you do anything, leave 'code' empty and send a message.
 
-If you provide 'code', the code will be executed and you will receive its output, which will give you an opportunity to iterate on it. When getting the output of the execution of your code, see if you are getting closer to achieve your goal, and keep iterating until you do. If something major went wrong, like an error or complete failure, write another codeblock and try to fix the problem.
+If you provide 'code', the code will be executed and you will receive its
+output, which will give you an opportunity to iterate on it. When getting the
+output of the execution of your code, see if you are getting closer to achieving
+your goal, and keep iterating until you do. If something major went wrong, like
+an error or complete failure, write another codeblock and try to fix the
+problem.
 
-This is extremely important to me, think step-by-step, take a deep breath and good luck! \nConversation:\n"""
+This is extremely important to me, think step-by-step, take a deep breath and
+good luck!
 
-persona_prompt = "your specific persona is: \n$PERSONA \n"
-skills_prompt = "The code is asynchronous and MUST CALL AWAIT for all async function calls. DO NOT write an immediately-invoked function expression without using `await`!! DO NOT WRITE LIKE THIS: '(async () => {console.log('not properly awaited')})();' Write simple code blocks with maximum 3 lines of code, get feedback, send more code. here is the reference of the javascript code syntax that you can use: \n\n $CODE_DOCS \n"
+Conversation:
+"""
+
+persona_prompt = "your specific persona is: \n$PERSONA\n"
+
+skills_prompt = """
+The code is asynchronous and MUST CALL AWAIT for all async function calls.
+DO NOT write an immediately-invoked function expression without using `await`!!
+DO NOT WRITE LIKE THIS: '(async () => {console.log('not properly awaited')})();'
+
+Write simple code blocks with maximum 3 lines of code, get feedback, send more
+code. here is the reference of the javascript code syntax that you can use:
+
+$CODE_DOCS
+"""
+
 examples_prompt = "Here are examples of Conversations: $EXAMPLES. "
 
 agent_prompt = "Your bot has the following configuration: $AGENT_MODE. "
@@ -27,54 +67,103 @@ coding_examples = [
         {"role": "user", "content": "greg: Collect 10 wood"},
         {
             "role": "assistant",
-            "content": { "code": "await skills.collectBlock(bot, 'oak_log', 10);", "message": "I collected 9 oak logs, what next?"},
-        }
+            "content": {
+                "code": "await skills.collectBlock(bot, 'oak_log', 10);",
+                "message": "I collected 9 oak logs, what next?",
+            },
+        },
     ],
     [
         {"role": "user", "content": "zZZn98: come here"},
         {
             "role": "assistant",
-            "content": { "code": "await skills.goToPlayer(bot, 'zZZn98');", "message": "I'm coming!"},
-        }
+            "content": {
+                "code": "await skills.goToPlayer(bot, 'zZZn98');",
+                "message": "I'm coming!",
+            },
+        },
     ],
     [
         {"role": "user", "content": "maya: go to the nearest oak log"},
         {
             "role": "assistant",
-            "content": { "code": "await skills.goToPosition(bot, nearestOakLog.x, nearestOakLog.y, nearestOakLog.z);", "message": "Here!"}
+            "content": {
+                "code": "await skills.goToPosition(bot, nearestOakLog.x, nearestOakLog.y, nearestOakLog.z);",
+                "message": "Here!",
+            },
         },
         {"role": "system", "content": "Arrived at location."},
-        {
-            "role": "assistant",
-            "content": "I found an oak log and I am now standing next to it. What next?"
-        }
+        {"role": "assistant", "content": "I found an oak log and I am now standing next to it. What next?"},
     ],
     [
         {"role": "user", "content": "234jeb: build a little tower with a torch on the side"},
         {
             "role": "assistant",
-            "content": { "code": "let pos = bot.entity.position;\nfor (let i = 0; i < 5; i++) {\n    await skills.placeBlock(bot, 'dirt', pos.x, pos.y + i, pos.z);\n}\nawait skills.placeBlock(bot, 'torch', pos.x + 1, pos.y + 4, pos.z, 'side');\n", "message": "Successfully placed 5 dirt."},
-        }
+            "content": {
+                "code": textwrap.dedent(
+                    """
+                    let pos = bot.entity.position;
+                    for (let i = 0; i < 5; i++) {
+                        await skills.placeBlock(bot, 'dirt', pos.x, pos.y + i, pos.z);
+                    }
+                    await skills.placeBlock(bot, 'torch', pos.x + 1, pos.y + 4, pos.z, 'side');
+                    """
+                ),
+                "message": "Successfully placed 5 dirt.",
+            },
+        },
     ],
     [
         {"role": "user", "content": "brug: build a dirt house"},
         {
             "role": "assistant",
-            "content" : { "code": "const position = world.getPosition(bot);\nconst startX = position.x;\nconst startY = position.y;\nconst startZ = position.z;\nconst width = 4;\nconst depth = 4;\nconst height = 3;\n\n// Build the walls\nfor (let x = startX; x < startX + width; x++) {\n    for (let y = startY; y < startY + height; y++) {\n        for (let z = startZ; z < startZ + depth; z++) {\n            if (x === startX || x === startX + width - 1 || y === startY || y === startY + height - 1 || z === startZ || z === startZ + depth - 1) {\n                await skills.placeBlock(bot, 'oak_planks', x, y, z);  \n            }\n       }\n    }\n}\n", "message": "Successfully placed 5 dirt."},
+            "content": {
+                "code": textwrap.dedent(
+                    """
+                    const position = world.getPosition(bot);
+                    const startX = position.x;
+                    const startY = position.y;
+                    const startZ = position.z;
+                    const width = 4;
+                    const depth = 4;
+                    const height = 3;
+
+                    // Build the walls
+                    for (let x = startX; x < startX + width; x++) {
+                        for (let y = startY; y < startY + height; y++) {
+                            for (let z = startZ; z < startZ + depth; z++) {
+                                if (x === startX || x === startX + width - 1 ||
+                                    y === startY || y === startY + height - 1 ||
+                                    z === startZ || z === startZ + depth - 1) {
+                                    await skills.placeBlock(bot, 'oak_planks', x, y, z);
+                                }
+                            }
+                        }
+                    }
+                    """
+                ),
+                "message": "Successfully placed 5 dirt.",
+            },
         },
     ],
     [
         {"role": "user", "content": "jane: get into a defensive mode to protect yourself"},
         {
             "role": "assistant",
-            "content" : { "code": "await skills.setMode(bot, 'self_defense', true);", "message": "Setting mode self_defense to on. "},
+            "content": {
+                "code": "await skills.setMode(bot, 'self_defense', true);",
+                "message": "Setting mode self_defense to on. ",
+            },
         },
     ],
     [
         {"role": "user", "content": "john: its time to attack these enemies!"},
         {
             "role": "assistant",
-            "content" : { "code": "await skills.attackEntity(bot, 'zombie');", "message": "Successfully attacked."},
+            "content": {
+                "code": "await skills.attackEntity(bot, 'zombie');",
+                "message": "Successfully attacked.",
+            },
         },
     ],
 ]

--- a/agents/llm/simple_llm_agent.py
+++ b/agents/llm/simple_llm_agent.py
@@ -1,27 +1,62 @@
 from string import Template
 from typing import Any, Optional, cast
-from typing_extensions import TypeAlias
-from kradle import Agent, Context, Kradle
-from kradle.models import ChallengeInfo, MinecraftEvent, Observation
 
-from llm_clients import LLMClient, LLMError, LLMResponse, OpenRouterClient, parse_action_from_response
+from dotenv import load_dotenv
+from kradle import Agent, Context, Kradle, OnEventResponse
+from kradle.models import ChallengeInfo, MinecraftEvent, Observation
+from typing_extensions import TypeAlias
+
+from llm_clients import (
+    LLMClient,
+    LLMError,
+    LLMResponse,
+    OpenRouterClient,
+    message_with_details,
+    parse_action_from_response,
+)
 from prompts import config
 
+"""
+An example of a Minecraft-playing agent based on communication with an LLM.
 
-# Let's define a model and persona for our agent
+This script can be run directly. To run it, you must supply a Kradle API key,
+either via the KRADLE_API_KEY environment variable or by setting the API key
+in a .env file in this directory. See .env-example for other values you can set.
 
-# Username of the agent in kradle (e.g.
-# kradle.ai/<my-username>/agents/<my-agent-username>). Will be created if it
-# doesn't exist.
-USERNAME = "python1"
+If you run this script, it will register an agent with the given AGENT_NAME
+with Kradle using a tunnel to create a temporary public URL so that the Kradle
+web UI or Kradle Studio can connect to it.
 
-# Refer to https://openrouter.ai/models for all available models.
+After running the script, go to the Kradle web UI or Kradle Studio to start
+challenges to test your agent.
+"""
+
+# AGENT_NAME is the name of the agent in Kradle. Agent names are unique within
+# your Kradle user account. Think of this as naming a particular strategy; you
+# might iterate on that strategy but the name will stick.
+#
+# During and after your agent is running it will have a unique URL:
+# https://kradle.ai/<my-username>/agent/<my-agent-name>.
+AGENT_NAME = "python1"
+
+# The OpenRouter model ID for the large language model to use. Refer to
+# https://openrouter.ai/models for available models. Use the "copy model ID"
+# button to quickly get this value for the model you want to use.
+#
+# If you choose to use a different LLM API provider, use the appropriate model
+# name or ID for that provider.
 MODEL = "google/gemini-2.0-flash-001"
 
-# Check out some other personas in prompts/config.py.
-PERSONA = "you are a cool resourceful agent. you really want to achieve the task that has been given to you."
-
-# Plus some additional settings:
+# This example builds up a prompt for your LLM containing broad instructions,
+# reference documentation for the available skills, some code examples, etc.
+# Along with this it includes a "personality prompt" that can help guide the
+# agent's overall behavior. You can use this to get the agent to be more
+# aggressive or to bias more toward building, exploration, or whatever else you
+# might want it to focus on.
+#
+# Note: this is just a feature of this example and is not required for your
+# agents if you don't want it.
+PERSONALITY_PROMPT = "you are a cool resourceful agent. you really want to achieve the task that has been given to you."
 
 # This adds a delay (in milliseconds) after an action is performed. Increase
 # this if the agent is too fast or if you want more time to see the agent's
@@ -34,20 +69,45 @@ MAX_RETRIES = 3
 
 def setup(kradle: Kradle) -> Agent:
     agent = kradle.agent(
-        username=USERNAME,
-        display_name=f"{USERNAME} (llm)",
+        name=AGENT_NAME,
+        # The name that will show up in the Kradle web UI.
+        display_name=f"{AGENT_NAME} (llm)",
+        # A short description of the agent.
         description="This is an LLM-based agent that can be used to perform tasks in Minecraft.",
+        # Any additional configuration you want to supply to the agent. This is
+        # optional, but for the sake of this example, we'll plumb through the
+        # values above:
+        config={
+            "model": MODEL,
+            "delay_after_action": DELAY_AFTER_ACTION,
+            "max_retries": MAX_RETRIES,
+            "personality_prompt": PERSONALITY_PROMPT,
+        },
     )
 
-    # This method is called when the session starts.
+    # You register handlers for certain events using decorators like this. The
+    # Kradle SDK will call any function decorated with @agent.init when a
+    # challenge run starts. You can use this to do any setup you need.
+    #
+    # Each participant will get their own `Context` object. You can use this to
+    # store any state specific to that participant. No two participants will
+    # share the same context, even if they're running in the same Python
+    # process.
     @agent.init
     def init(challenge: ChallengeInfo, context: Context):
-        context["client"] = OpenRouterClient(MODEL, kradle.api)
-        context["history"] = []
-        context["model"] = MODEL
-        context["persona"] = PERSONA
-        context["delay_after_action"] = DELAY_AFTER_ACTION
+        # Use the OpenRouter client to make API calls to the LLM. There are
+        # other clients available, see llm_clients.py for more.
+        context["client"] = OpenRouterClient(context.config["model"], kradle.api)
 
+        # Keep track of the conversation history with the LLM.
+        context["history"] = []
+
+    # Aside from init, the system will then generate `Observation` objects for
+    # your agent to process. You register interest in certain events by using
+    # `@agent.event` decorator.
+    #
+    # For any given participant, the same `Context` object will be passed
+    # repeatedly to your event handler.
     @agent.event(
         MinecraftEvent.INITIAL_STATE,
         MinecraftEvent.CHAT,
@@ -55,36 +115,37 @@ def setup(kradle: Kradle) -> Agent:
         MinecraftEvent.COMMAND_EXECUTED,
         MinecraftEvent.IDLE,
     )
-    def event(observation: Observation, context: Context):
+    def event(observation: Observation, context: Context) -> OnEventResponse:
+        # Context values are untyped. If you're using type annotations, you can
+        # declare locals like this to impose a type on these values.
         client: LLMClient = context["client"]
-        history: list[Message] = context["history"]
 
+        # LLMs can fail to generate valid responses to a prompt, so attempt to
+        # get a reasonable response up to MAX_RETRIES times. Note that by
+        # pushing an error into the history, the next attempt will incorporate
+        # the error message in the prompt.
         for attempt in range(MAX_RETRIES):
             llm_prompt = format_llm_prompt(observation, context)
             show_heading(llm_prompt, attempt)
 
-            # TODO(wilhuff): This still needs simplification work.
             try:
                 response = client.get_chat_completion(llm_prompt)
                 action = parse_action_from_response(response)
-                log_result(llm_prompt, response.content, context)
-                return action
-            except LLMError as e:
-                print(f"Error: {e.message_with_details()}")
-                history_push_error(history, str(e))
-                log_result(llm_prompt, e.content, context)
-                continue
+                record_result(llm_prompt, response, None, context)
+                return {
+                    **action,
+                    "delay": context.config["delay_after_action"],
+                }
             except Exception as e:
-                print(f"Error: {e}")
-                history_push_error(history, str(e))
-                log_result(llm_prompt, response.content if response else None, context)
+                print(f"Error: {message_with_details(e)}")
+                record_result(llm_prompt, response, e, context)
                 continue
 
         # If we fall out of the loop, we've failed.
         return {
             "code": "",
             "message": "I'm sorry, I'm having trouble generating a response. Please try again later.",
-            "delay": context["delay_after_action"],
+            "delay": context.config["delay_after_action"],
         }
 
     return agent
@@ -95,8 +156,24 @@ Messages: TypeAlias = list[Message]
 
 
 def format_llm_prompt(observation: Observation, context: Context) -> Messages:
+    """
+    Combines the challenge, the current observation, history, and other information
+    into a list of prompt messages to be sent to an LLM. Messages are of the
+    form
+
+    ```
+    {
+        "role": "system" | "developer" | "user" | "assistant" | "tool",
+        "content": str
+    }
+    ```
+
+    as described in the OpenRouter API documentation.
+
+    See https://openrouter.ai/docs/api-reference/chat-completion."""
+
     challenge = context.challenge_info
-    persona = context["persona"]
+    persona = context.config["personality_prompt"]
     history = context["history"]
     result = [
         *format_system_prompt(challenge, observation),
@@ -109,14 +186,19 @@ def format_llm_prompt(observation: Observation, context: Context) -> Messages:
 
 
 def format_system_prompt(challenge: ChallengeInfo, observation: Observation) -> Messages:
+    """
+    Formats system prompt messages for the LLM.
+    """
+
+    # Tell the LLM which Minecraft mode it's playing in.
     if challenge.agent_modes["mcmode"] == "creative":
         creative_mode = config.creative_mode_prompt
     else:
         creative_mode = "You are in survival mode."
 
     result = [
-        # Build coding prompt from template, including task, agent_modes,
-        # and creative_mode
+        # The coding prompt gives the LLM high-level instructions about the
+        # problem it needs to solve.
         substitute(
             config.coding_prompt,
             NAME=observation.name,
@@ -124,13 +206,13 @@ def format_system_prompt(challenge: ChallengeInfo, observation: Observation) -> 
             AGENT_MODE=challenge.agent_modes,
             CREATIVE_MODE=creative_mode,
         ),
-        # Skills prompt with code documentation to give the agent context
-        # about the available commands
+        # The skills prompt gives the LLM code documentation about the available
+        # commands.
         substitute(config.skills_prompt, CODE_DOCS=challenge.js_functions),
         # Minecraft modes (creative, self_preservation, etc) available in
         # the challenge
         substitute(config.agent_prompt, AGENT_MODE=challenge.agent_modes),
-        # Examples prompt
+        # The examples prompt gives the LLM examples of code it could generate.
         substitute(config.examples_prompt, EXAMPLES=config.coding_examples),
     ]
 
@@ -138,21 +220,21 @@ def format_system_prompt(challenge: ChallengeInfo, observation: Observation) -> 
 
 
 def format_history_prompt(history: list[Message]) -> Messages:
+    """
+    Returns the last 5 messages in the conversation history to feed into the
+    next LLM prompt.
+    """
     return history[-5:]
-
-
-def push_history(history: list[Message], llm_prompt: Messages, response: LLMResponse) -> None:
-    request = llm_prompt[-1]["content"]
-    history.append({"role": "user", "content": request})
-    history.append({"role": "assistant", "content": response.content})
-
-
-def history_push_error(history: list[Message], error: str) -> None:
-    history.append({"role": "system", "content": f"your last response was not valid because: {error}"})
 
 
 def format_observation(observation: Observation) -> str:
     """Converts observation object to a string for the LLM prompt."""
+
+    def _format_value(value: Any) -> Any:
+        return value if value else "None"
+
+    def _format_list(items: list[str]) -> str:
+        return ", ".join(items) if items else "None"
 
     # Let's get everything in our inventory
     inventory_summary = _format_list([f"{count} {name}" for name, count in observation.inventory.items()])
@@ -180,20 +262,19 @@ def format_observation(observation: Observation) -> str:
     return "\n\n".join(result)
 
 
-def _format_value(value: Any) -> Any:
-    return value if value else "None"
-
-
-def _format_list(items: list[str]) -> str:
-    return ", ".join(items) if items else "None"
-
-
 def substitute(prompt: str, **kwargs) -> str:
+    """
+    Uses Python template strings to substitute variables into pre-built,
+    parameterized prompts.
+    """
     template = Template(prompt)
     return template.safe_substitute(**kwargs)
 
 
 def show_heading(llm_prompt: Messages, attempt: int) -> None:
+    """
+    Prints a big blocky heading to the console to indicate the start of an LLM call.
+    """
     if attempt == 0:
         print(f"\033[91m########################################################")
         print(f"\nObservation Summary:\n{llm_prompt[-1]['content']}")
@@ -206,10 +287,45 @@ def show_heading(llm_prompt: Messages, attempt: int) -> None:
     print(f"LLM Prompt: {llm_prompt}")
 
 
+def record_result(
+    llm_prompt: Messages,
+    response: Optional[LLMResponse],
+    error: Optional[Exception],
+    context: Context,
+) -> None:
+    """
+    Records the result of an LLM call both in the conversation history and
+    remotely via the Kradle API.
+    """
+    history: list[Message] = context["history"]
+
+    request = llm_prompt[-1]["content"]
+    history.append({"role": "user", "content": request})
+
+    content: Optional[str]
+    if response and response.content:
+        content = response.content
+    elif isinstance(error, LLMError) and error.content:
+        content = error.content
+    else:
+        content = None
+
+    if content:
+        history.append({"role": "assistant", "content": content})
+
+    if error:
+        history.append({"role": "system", "content": f"your last response was not valid because: {str(error)}"})
+
+    log_result(llm_prompt, content, context)
+
+
 def log_result(llm_prompt: Messages, response: Optional[str], context: Context) -> None:
+    """
+    Logs the result of an LLM call to the Kradle API for display in the UI.
+    """
     message = {
         "prompt": truncate_prompt(llm_prompt),
-        "model": context["model"],
+        "model": context.config["model"],
         "response": response,
     }
 
@@ -218,18 +334,23 @@ def log_result(llm_prompt: Messages, response: Optional[str], context: Context) 
     context.log(cast(str, message))
 
 
-# Utility function to truncate the prompt to 2000 characters for more readable logs
-def truncate_prompt(prompt: Messages) -> Messages:
+def truncate_prompt(prompt: Messages, length: int = 2000) -> Messages:
+    """
+    Truncates prompt messages to a maximum length, useful for creating more
+    readable logs.
+    """
     truncated_prompt = []
     for p in prompt:
         truncated_p = p.copy()  # Create a shallow copy of the dict
-        if len(truncated_p["content"]) > 2000:
-            truncated_p["content"] = truncated_p["content"][:2000] + "..."
+        if len(truncated_p["content"]) > length:
+            truncated_p["content"] = truncated_p["content"][:length] + "..."
         truncated_prompt.append(truncated_p)
     return truncated_prompt
 
 
 if __name__ == "__main__":
+    load_dotenv()
+
     kradle = Kradle(create_public_url=True, debug=True)
     agent = setup(kradle)
     app, connection_info = agent.serve()


### PR DESCRIPTION
This mostly involves lots of comments. However, there are some specific changes in here worth calling out:

  * I've implemented the new `context` parameter instead of the `run` context-local.
  * I've simplified the error handling even more than before.
  * I've used textwrap.dedent to clean up docstrings. For example, our code examples should have no leading indent when sent to the LLM but should be indented in the code. Dedenting the string gives us the best of both worlds: easy to edit examples that nevertheless end up formatted correctly when sent.
  * I've added the missing call to `load_dotenv` that was causing trouble for us in yesterday's user testing session (doh).
  * I've added substantial pedagogical commentary to the simple_llm_agent.py.

Rather than break this apart into separate commits for easier review, I've sent you the whole mess as one, just to speed things along in time for tomorrow's user tests.
